### PR TITLE
Add shard for pc tournament matches

### DIFF
--- a/apis.go
+++ b/apis.go
@@ -45,6 +45,8 @@ const (
 	PCSouthEastAsia = "pc-sea"
 	// PCSouthAsia - PC South Asia Region
 	PCSouthAsia = "pc-sa"
+	// PCTournament - PC Tournament Shard
+	PCTournament = "pc-tournament"
 )
 
 // GetQueueSize returns the current size of the poller queue.


### PR DESCRIPTION
Per https://documentation.playbattlegrounds.com/en/making-requests.html if you want to query match information about tournaments you need to pass it the pc-tournament shard.